### PR TITLE
feat: including backend part of the webCrawler

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,6 +1,6 @@
 const express = require('express') // node server
 const cors = require('cors') // CORS
-const scraper = require('./scraper')
+const scraper = require('./scraper') 
 
 const app = express()
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,36 +1,26 @@
 const express = require('express') // node server
-const axios = require('axios') // library to do http requests
 const cors = require('cors') // CORS
-const cheerio = require('cheerio') // library to manipulate HTML
-
-const baseUrl = 'https://news.ycombinator.com/'
+const scraper = require('./scraper')
 
 const app = express()
 
 app.use(cors())
 
-const getScraping = () => {
-    const request = axios.get(baseUrl)
-    return request.then(response => {
-        const $ = cheerio.load(response.data)
-        const titles = $('.titleline').each((_,element) => {
-            const $element = $(element)
-            const title = $element.find('a').first() // first a has the title if not you can get more a inside the span
-            const titleText = title.text()
-            console.log(titleText)
-        }
-        )
-    })
-}
-
-
-app.get('/health', (request,response) => {
+app.get('/api/health', (request,response) => {
     response.send('<p>Healthy :)<p>')
 })
 
-app.get('/scraping',(request,response) => {
-    getScraping()
-    response.status(204).end()
+app.get('/api/scraping',(request,response) => {
+    scraper
+    .getScraping()
+    .then(result => {
+        response.json(result)
+    }).catch( err => {
+        console.log(err)
+        response.status(500).json({
+            error: 'scraping failure'
+        })
+    })
 })
 
 const PORT = 3001

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.4",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.4",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Backend for the webCrawlerYCombinator",
   "main": "index.js",
   "scripts": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Backend for the webCrawlerYCombinator",
   "main": "index.js",
   "scripts": {

--- a/backend/scraper.js
+++ b/backend/scraper.js
@@ -1,0 +1,27 @@
+const axios = require('axios') // library to do http requests
+const cheerio = require('cheerio') // library to manipulate HTML
+const baseUrl = 'https://news.ycombinator.com/'
+
+const getScraping = () => {
+    return axios.get(baseUrl)
+        .then(response => 
+            {
+                // works just like $ jQuery function
+                const $ = cheerio.load(response.data)
+                const entries = $('tr.athing').map((_,element) => { // get all the tr.athing in the page
+                    const titlesText = $(element).find('td.title span.titleline a').first().text() // get the first a element that contains the title
+                    const subTitleText =  $(element).next('tr').find('td.subtext span.subline') // get sublines tat contains score and comments
+                    const score = subTitleText.find('span.score').text()
+                    const comments = subTitleText.find('a').last().text()
+                    return { pos: _ + 1, title: titlesText, score: score, comments: comments}
+                })
+                .toArray() // to transform jQuery elements to JS array
+                
+                return entries
+            }
+        )
+}
+
+module.exports = {
+    getScraping
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature 
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Added backend part of the webCrawler:
- `index.js`: Contains two endpoints
    - `/api/health`: Health url that returns a healthy message to check fastly if our backend is working.
    - `/api/scraping`: Endpoint that use the data from `scraper.js` and shows it in JSON format.
- `scraper.js`: Contains the function `getScraping` that gets the data from `https://news.ycombinator.com/` and creates and object 

## Related Tickets & Documents
- [Cheerios]( https://cheerio.js.org/docs/basics/selecting) library for manipulting HTML
- [Example of web scraping](https://www.zenrows.com/blog/axios-web-scraping#what-website-you-scrape) just to get some ideas